### PR TITLE
Change APPROVE_ACCOUNTS_EMAIL to ACCOUNTS_EMAIL

### DIFF
--- a/project_application/__init__.py
+++ b/project_application/__init__.py
@@ -19,3 +19,6 @@ from karaage.plugins import BasePlugin
 
 class plugin(BasePlugin):
     name = "project_application"
+    settings = {
+        'APPROVE_ACCOUNTS_EMAIL': None,
+    }

--- a/project_application/emails.py
+++ b/project_application/emails.py
@@ -5,7 +5,7 @@ from django.core.mail import EmailMessage
 from django.conf import settings
 
 CONTEXT = {
-    'org_email': settings.APPROVE_ACCOUNTS_EMAIL,
+    'org_email': settings.ACCOUNTS_EMAIL,
     'org_name': settings.ACCOUNTS_ORG_NAME,
 }
 
@@ -43,7 +43,7 @@ def send_start_email(project_application, link):
     email = EmailMessage(
                 subject,
                 body,
-                settings.APPROVE_ACCOUNTS_EMAIL,
+                settings.ACCOUNTS_EMAIL,
                 [to_email],
                 headers=HEADERS)
     return email.send(fail_silently=False)
@@ -64,7 +64,7 @@ def send_submit_receipt(project_application, pdf):
     email = EmailMessage(
                 subject,
                 body,
-                settings.APPROVE_ACCOUNTS_EMAIL,
+                settings.ACCOUNTS_EMAIL,
                 [to_email],
                 attachments=[
                         ('%s-Project-Application-%s.pdf'%(
@@ -86,7 +86,7 @@ def send_notify_admin(project_application, link):
     email = EmailMessage(
                 subject,
                 body,
-                settings.APPROVE_ACCOUNTS_EMAIL,
+                settings.ACCOUNTS_EMAIL,
                 [to_email],
                 headers=HEADERS)
     return email.send(fail_silently=False)


### PR DESCRIPTION
APPROVE_ACCOUNTS_EMAIL is used by kgapplications to send outgoing emails
to administrators. i.e. it is the email address of the administrators.

ACCOUNTS_EMAIL is the email address intended to be used in the From:
field.